### PR TITLE
[31기 남용현] ADD: 몬스터 과제 완료 (CardList 배치 & 검색기능 구현 완료)

### DIFF
--- a/src/Assignments/Monsters/Components/Card/Card.js
+++ b/src/Assignments/Monsters/Components/Card/Card.js
@@ -1,5 +1,5 @@
-import React from "react";
-import "./Card.scss";
+import React from 'react';
+import './Card.scss';
 
 /***********************************************************
   Card 컴포넌트 구조
@@ -17,8 +17,14 @@ import "./Card.scss";
   Name 과 Email 도 마찬가지입니다.
 ***********************************************************/
 
-function Card() {
-  return <div className="cardContainer"></div>;
+function Card({ name, email, id }) {
+  return (
+    <div className="cardContainer">
+      <img src={`https://robohash.org/${id}?set=set2&size=180x180`} alt="몬스터 사진" />
+      <h2>{name}</h2>
+      <p>{email}</p>
+    </div>
+  );
 }
 
 export default Card;

--- a/src/Assignments/Monsters/Components/CardList/CardList.js
+++ b/src/Assignments/Monsters/Components/CardList/CardList.js
@@ -9,10 +9,13 @@ import './CardList.scss';
   Card 컴포넌트에서 필요로 하는 데이터는 id, name, email 입니다.
 ***********************************************************/
 
-function CardList({ monsters }) {
+function CardList({ monsters, userInput }) {
+  const filtered = monsters.filter((item) => {
+    return item.name.toUpperCase().includes(userInput.toUpperCase());
+  });
   return (
     <div className="cardList">
-      {monsters.map((item) => {
+      {filtered.map((item) => {
         return <Card key={item.id} name={item.name} email={item.email} id={item.id} />;
       })}
     </div>

--- a/src/Assignments/Monsters/Components/CardList/CardList.js
+++ b/src/Assignments/Monsters/Components/CardList/CardList.js
@@ -1,7 +1,7 @@
-import React from "react";
+import React from 'react';
 // import Monsters from "../../Monsters";
-import Card from "../Card/Card";
-import "./CardList.scss";
+import Card from '../Card/Card';
+import './CardList.scss';
 
 /***********************************************************
   Card 컴포넌트를 import 한 뒤, props로 내려받은 데이터에 
@@ -9,8 +9,14 @@ import "./CardList.scss";
   Card 컴포넌트에서 필요로 하는 데이터는 id, name, email 입니다.
 ***********************************************************/
 
-function CardList() {
-  return <div className="cardList"></div>;
+function CardList({ monsters }) {
+  return (
+    <div className="cardList">
+      {monsters.map((item) => {
+        return <Card key={item.id} name={item.name} email={item.email} id={item.id} />;
+      })}
+    </div>
+  );
 }
 
 export default CardList;

--- a/src/Assignments/Monsters/Components/CardList/CardList.js
+++ b/src/Assignments/Monsters/Components/CardList/CardList.js
@@ -11,7 +11,11 @@ import './CardList.scss';
 
 function CardList({ monsters, userInput }) {
   const filtered = monsters.filter((item) => {
-    return item.name.toUpperCase().includes(userInput.toUpperCase());
+    console.log(item);
+    return (
+      item.name.toUpperCase().includes(userInput.toUpperCase()) ||
+      item.email.toUpperCase().includes(userInput.toUpperCase())
+    );
   });
   return (
     <div className="cardList">

--- a/src/Assignments/Monsters/Monsters.js
+++ b/src/Assignments/Monsters/Monsters.js
@@ -1,7 +1,7 @@
-import React, { useState } from "react";
-import SearchBox from "./Components/SearchBox/SearchBox";
-import CardList from "./Components/CardList/CardList";
-import "./Monsters.scss";
+import React, { useEffect, useState } from 'react';
+import SearchBox from './Components/SearchBox/SearchBox';
+import CardList from './Components/CardList/CardList';
+import './Monsters.scss';
 
 /**********************************************************
   API 주소: https://jsonplaceholder.typicode.com/users
@@ -22,17 +22,31 @@ import "./Monsters.scss";
 
 function Monsters() {
   const [monsters, setMonsters] = useState([]);
-  const [userInput, setUserInput] = useState("");
+  const [userInput, setUserInput] = useState('');
+
+  const getData = async () => {
+    const data = await fetch('https://jsonplaceholder.typicode.com/users').then((res) =>
+      res.json()
+    );
+
+    setMonsters(data);
+  };
 
   // 데이터 로딩
+  useEffect(() => {
+    getData();
+  }, []);
 
   // SearchBox 에 props로 넘겨줄 handleChange 메소드 정의
+  const handleChange = (e) => {
+    setUserInput(e.target.value);
+  };
 
   return (
     <div className="monsters">
       <h1>컴포넌트 재사용 연습!</h1>
-      {/* <SearchBox handleChange=정의한메소드 /> */}
-      {/* <CardList monsters=몬스터리스트 /> */}
+      <SearchBox handleChange={handleChange} />
+      <CardList monsters={monsters} userInput={userInput} />
     </div>
   );
 }

--- a/src/Assignments/Monsters/Monsters.js
+++ b/src/Assignments/Monsters/Monsters.js
@@ -23,12 +23,13 @@ import './Monsters.scss';
 function Monsters() {
   const [monsters, setMonsters] = useState([]);
   const [userInput, setUserInput] = useState('');
+  const [loading, setLoading] = useState(true);
 
   const getData = async () => {
     const data = await fetch('https://jsonplaceholder.typicode.com/users').then((res) =>
       res.json()
     );
-
+    setLoading(false);
     setMonsters(data);
   };
 
@@ -46,7 +47,7 @@ function Monsters() {
     <div className="monsters">
       <h1>컴포넌트 재사용 연습!</h1>
       <SearchBox handleChange={handleChange} />
-      <CardList monsters={monsters} userInput={userInput} />
+      {loading ? <h1>로딩중입니다.</h1> : <CardList monsters={monsters} userInput={userInput} />}
     </div>
   );
 }


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 
- 몬스터 카드를 데이터 로드 후 카드리스트 형태로 배치
- 몬스터 카드 검색 기능  

<br />

## :: 구현 사항 설명
1. 몬스터 카드 데이터 로드
- fetch 메소드를 통해 해당 API를 로드
- async/await 으로 비동기 처리
- useEffect 훅을 사용하여 첫 마운트시 로드
- API 비동기 데이터 로딩시 로딩중이라는 예외처리 구현  

  
2. 카드리스트 배치
- 비동기 데이터를 props를 이용하여 자식에게 전달
- 받아온 props를 map 배열함수로 카드 컴포넌트 리스트화 

3. 검색 기능 구현
- filter 배열 함수를 통해 검색기능 구현
- 몬스터의 이름 & 이메일이 검색값과 일치할 때 해당 카드만 필터 

<br />

## :: 성장 포인트
- props의 전달 state의 사용 map 함수 사용 등 필수 적인 것을 한번 더 연습하게 되었습니다.
- 검색기능 구현을 통해 filter를 이용하는 방법을 연습 할 수 있었습니다.
- 공식문서를 보는방법, 검색했을때 그것을 내 것으로 만들고 잘 활용 할 수 있는 방법을 연습하게 되어서 한계단 더 오른거 같아 기분이 좋습니다.
   
<br />

## :: 기타 질문 및 특이 사항

